### PR TITLE
COOK-1486 Adding super call to config resource's call to initialize()

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -49,6 +49,7 @@ VALID_SERVER_HOOK_NAMES = [
 ]
 
 def initialize(*args)
+  super
   @action = :create
 end
 


### PR DESCRIPTION
@kotiri added a default action in 228a9f30028362654a3b7e4eafe890e3b4ad01f5

Except initialize() is missing a call to super: http://wiki.opscode.com/display/chef/Lightweight+Resources+and+Providers+(LWRP)#LightweightResourcesandProviders%28LWRP%29-DefaultAction

JIRA: http://tickets.opscode.com/browse/COOK-1486

PLEASEREVIEW: @jtimberman @kotiri
