### PR TITLE
[COOK-1897] fixed idempotency problem. notification handler fired every chef run

### DIFF
--- a/libraries/chefext.rb
+++ b/libraries/chefext.rb
@@ -1,0 +1,37 @@
+#
+## This pattern was invented by yfeldblum to aid in determining whether or not a lwrp
+## should set updated_by_last_action to _true_ if it's composed entirely of other
+## idempotent resources. 
+#
+## https://gist.github.com/d85be145f3ff824ccc07
+#
+
+module ChefExt
+  module RecipeEval
+
+    protected
+
+    def recipe_eval
+
+      sub_run_context = @run_context.dup
+      sub_run_context.resource_collection = Chef::ResourceCollection.new
+
+      begin
+        original_run_context, @run_context = @run_context, sub_run_context
+        yield
+      ensure
+        @run_context = original_run_context
+      end
+
+      begin
+        Chef::Runner.new(sub_run_context).converge
+      ensure
+        if sub_run_context.resource_collection.any?(&:updated?)
+          new_resource.updated_by_last_action(true)
+        end
+      end
+
+    end
+
+  end
+end

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -18,15 +18,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This provider uses the "subresources" notifier pattern defined here:
+#
+# https://gist.github.com/d85be145f3ff824ccc07
+# http://realityforge.org/code/2012/07/17/lwrp-notify-on-changed-resources.html
+
+include ChefExt::RecipeEval
+
 action :install do
-  python_virtualenv new_resource.virtualenv do
-    action :create
-  end if new_resource.virtualenv
-
-  python_pip "gunicorn" do
-    virtualenv new_resource.virtualenv
-    action :install
+  recipe_eval do
+    python_virtualenv new_resource.virtualenv do
+      action :create
+    end if new_resource.virtualenv
+  
+    python_pip "gunicorn" do
+      virtualenv new_resource.virtualenv
+      action :install
+    end
   end
-
-  new_resource.updated_by_last_action(true)
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-1897

The lwrp in this cookbook is just implemented incorrectly. It shows up as having run in the notification handlers every single chef run. Since this lwrp is entirely composed of idempotent resources from the python cookbook I used yfeldblum's ChefExt::recipe_eval wrapper to notify correctly if any of the sub-resources fired.
