### PR TITLE
[COOK-3019] start_server isn't a valid server_hook, this should be when_ready

### DIFF
--- a/templates/default/gunicorn.py.erb
+++ b/templates/default/gunicorn.py.erb
@@ -43,7 +43,7 @@ def on_reload(server):
 
 <%- if @server_hooks[:when_ready] %>
 # What to do after the server starts
-def start_server(server):
+def when_ready(server):
     <%= @server_hooks[:when_ready] %>
 
 <%- end %>


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3019

See the full list at http://docs.gunicorn.org/en/latest/configure.html#server-hooks
