### PR TITLE
[COOK-4530] Enable new options in gunicorn config for secure headers from proxy and proc name

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Creates a Gunicorn configuration file at the path specified.  Meant to be deploy
 - loglevel: The granularity of error log outputs.
 - logger_class: The logger you want to use to log events in gunicorn.
 - logconfig: The log config file to use.
+- secure_scheme_headers: A hash containing headers and values that the front-end proxy uses to indicate HTTPS requests.
+- forwarded_allow_ips: Front-end’s IPs from which allowed to handle set secure headers. (comma separate).
+- proc_name: A base to use with setproctitle for process naming.
+
 
 # Example
 

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -40,6 +40,10 @@ attribute :errorlog, :kind_of => String, :default => nil
 attribute :loglevel, :kind_of => String, :default => nil
 attribute :logger_class, :kind_of => String, :default => nil
 attribute :logconfig, :kind_of => String, :default => nil
+attribute :secure_scheme_headers, :kind_of => Hash, :default => nil
+attribute :forwarded_allow_ips, :kind_of => String, :default => nil
+attribute :proc_name, :kind_of => String, :default => nil
+
 
 attribute :server_hooks, :kind_of => Hash, :default => {}, \
     :callbacks => {

--- a/templates/default/gunicorn.py.erb
+++ b/templates/default/gunicorn.py.erb
@@ -116,3 +116,22 @@ logger_class = "<%= @logger_class %>"
 logconfig = "<%= @logconfig %>"
 
 <%- end %>
+<%- if @secure_scheme_headers %>
+# A dictionary containing headers and values that the front-end proxy uses to indicate HTTPS requests.
+secure_scheme_headers = {
+  <%- @secure_scheme_headers.each do |header,value| %>
+  "<%= header %>": "<%= value%>",
+  <%- end %>
+}
+
+<%- end %>
+<%- if @forwarded_allow_ips %>
+# Front-end’s IPs from which allowed to handle set secure headers. (comma separate).
+forwarded_allow_ips = "<%= @forwarded_allow_ips %>"
+
+<%- end %>
+<%- if @proc_name %>
+# A base to use with setproctitle for process naming.
+proc_name = "<%= @proc_name %>"
+
+<%- end %>


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-4530
- secure_scheme_headers
- forwarded_allow_ips
- proc_name

Reference
- http://docs.gunicorn.org/en/latest/settings.html#process-naming
- http://docs.gunicorn.org/en/latest/settings.html#secure-scheme-headers
- http://docs.gunicorn.org/en/latest/settings.html#forwarded-allow-ips
