### PR TITLE
Update README.md to remove smart magic quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Creates a Gunicorn configuration file at the path specified.  Meant to be deploy
 - logger_class: The logger you want to use to log events in gunicorn.
 - logconfig: The log config file to use.
 - secure_scheme_headers: A hash containing headers and values that the front-end proxy uses to indicate HTTPS requests.
-- forwarded_allow_ips: Front-end’s IPs from which allowed to handle set secure headers. (comma separate).
+- forwarded_allow_ips: Front-end's IPs from which allowed to handle set secure headers. (comma separate).
 - proc_name: A base to use with setproctitle for process naming.
 
 


### PR DESCRIPTION
On some versions of Chef and Ruby (particularly those currently available on AWS Opsworks), the smart magic quote in the README.md can cause installation errors:

```
/opt/aws/opsworks/local/lib/ruby/gems/2.0.0/gems/json-1.8.1/lib/json/common.rb:155:in `encode': "\xE2" on US-ASCII (Encoding::InvalidByteSequenceError)
```

This is an consequence of the following Chef bug, which has since been fixed: https://tickets.opscode.com/browse/COOK-522
