### PR TITLE
Added support for several missing variables. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Creates a Gunicorn configuration file at the path specified. Meant to be deploye
 - path: name attribute. The path where the configuration file will be created
 - template: template to use when rendering the configuration file. default is `gunicorn.py.erb` (part of this cookbook)
 - cookbook: cookbook to look for template file in. default is this cookbook `gunicorn`
-- listen: the socket to bind to. A string of the form: 'HOST', 'HOST:PORT', 'unix:PATH'. default is `0.0.0.0:8000` or listen on port 8000 on all interfaces
+- listen: the socket to bind to. A string of the form: 'HOST', 'HOST:PORT', 'unix:PATH'. default is `0.0.0.0:8000` or listen on port 8000 on all interfaces.  Can also be an array of addresses.
 - backlog: The maximum number of pending connections. default is `2048`
 - preload_app: Whether application code should be loaded before the worker processes are forked. default is `false`
 - worker_processes: The number of worker process for handling requests. default is `4`
@@ -49,6 +49,13 @@ Creates a Gunicorn configuration file at the path specified. Meant to be deploye
 - worker_timeout: The number of seconds to wait before a worker is killed and restarted. default is `60`
 - worker_keepalive: The number of seconds to wait for requests on a Keep-Alive connection. default is `2`
 - worker_max_requests: The maximum number of requests a worker will process before restarting. default is `0` or restarts disabled
+- worker_max_requests_jitter: The maximum jitter to add to the max_requests setting. default is `0`
+- worker_threads: The number of worker threads for handling requests. default is `1`
+- worker_connections: The maximum number of simultaneious clients. default is `1000`
+- worker_graceful_timeout: Timeout for graceful workers restart. default is `30`
+- limit_request_line: The maximum size of HTTP request line in bytes. default is `4094`
+- limit_request_fields: Limit the number of HTTP headers fields in a request. default is `100`
+- limit_request_field_size: Limit the allowed size of an HTTP request header field. default is `8190`
 - server_hooks: A hash with whose values will be rendered as a [Gunicorn server hook](http://gunicorn.org/configure.html#server-hooks) callables (functions) named after the hash item's key name. default is `{}` or no serves hooks
 - owner: The owner for the configuration file.
 - group: The group owner of the configuration file (string or id).
@@ -62,6 +69,7 @@ Creates a Gunicorn configuration file at the path specified. Meant to be deploye
 - secure_scheme_headers: A hash containing headers and values that the front-end proxy uses to indicate HTTPS requests.
 - forwarded_allow_ips: Front-end's IPs from which allowed to handle set secure headers. (comma separate).
 - proc_name: A base to use with setproctitle for process naming.
+- raw_env: An array of raw environment variables in the form of KEY=VALUE.  default is `nil`.
 
 #### Example
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache 2.0'
 description      'Installs/Configures Gunicorn'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.0'
+version          '2.0.1'
 
 depends 'python'
 

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -24,7 +24,34 @@ action :create do
   Chef::Log.info("Creating #{@new_resource} at #{@new_resource.path}") unless exists?
 
   template_variables = {}
-  %w(listen backlog preload_app worker_processes worker_class worker_timeout worker_keepalive worker_max_requests server_hooks pid accesslog access_log_format errorlog loglevel logger_class logconfig secure_scheme_headers forwarded_allow_ips proc_name).each do |a|
+  %w(
+    listen
+    backlog
+    preload_app
+    worker_processes
+    worker_class
+    worker_timeout
+    worker_keepalive
+    worker_max_requests
+    worker_max_requests_jitter
+    worker_connections
+    worker_threads
+    limit_request_line
+    limit_request_fields
+    limit_request_field_size
+    server_hooks
+    pid
+    accesslog
+    access_log_format
+    errorlog
+    loglevel
+    logger_class
+    logconfig
+    secure_scheme_headers
+    forwarded_allow_ips
+    proc_name
+    raw_env
+  ).each do |a|
     template_variables[a.to_sym] = new_resource.send(a)
   end
 

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -25,7 +25,7 @@ attribute :path, kind_of: String, name_attribute: true
 attribute :template, kind_of: String, default: 'gunicorn.py.erb'
 attribute :cookbook, kind_of: String, default: 'gunicorn'
 
-attribute :listen, kind_of: String, default: '0.0.0.0:8000'
+attribute :listen, kind_of: [String, Array], default: '0.0.0.0:8000'
 attribute :backlog, kind_of: Integer, default: 2048
 attribute :preload_app, kind_of: [TrueClass, FalseClass], default: false
 
@@ -34,6 +34,14 @@ attribute :worker_class, kind_of: String, default: 'sync'
 attribute :worker_timeout, kind_of: Integer, default: 60
 attribute :worker_keepalive, kind_of: Integer, default: 2
 attribute :worker_max_requests, kind_of: Integer, default: 0
+attribute :worker_max_requests_jitter, kind_of: Integer, default: 0
+attribute :worker_connections, kind_of: Integer, default: 1000
+attribute :worker_threads, kind_of: Integer, default: 1
+attrubyte :worker_graceful_timeout, kind_of: Integer, default: 30
+
+attribute :limit_request_line, kind_of: Integer, default: 4094
+attribute :limit_request_fields, kind_of: Integer, default: 100
+attribute :limit_request_field_size, kind_of: Integer, default: 8190
 
 attribute :accesslog, kind_of: String, default: nil
 attribute :access_log_format, kind_of: String, default: nil
@@ -45,10 +53,12 @@ attribute :secure_scheme_headers, kind_of: Hash, default: nil
 attribute :forwarded_allow_ips, kind_of: String, default: nil
 attribute :proc_name, kind_of: String, default: nil
 
-attribute :server_hooks, kind_of: Hash, default: {}, \
+attribute :server_hooks, kind_of: Hash, default: Hash.new, \
                          callbacks: {
                            'should contain a valid gunicorn server hook name' => ->(hooks) { Chef::Resource::GunicornConfig.validate_server_hook_hash_keys(hooks) },
                          }
+
+attribute :raw_env, kind_of: Array, default: nil
 
 attribute :owner, regex: Chef::Config[:user_valid_regex]
 attribute :group, regex: Chef::Config[:group_valid_regex]

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -37,7 +37,7 @@ attribute :worker_max_requests, kind_of: Integer, default: 0
 attribute :worker_max_requests_jitter, kind_of: Integer, default: 0
 attribute :worker_connections, kind_of: Integer, default: 1000
 attribute :worker_threads, kind_of: Integer, default: 1
-attrubute :worker_graceful_timeout, kind_of: Integer, default: 30
+attribute :worker_graceful_timeout, kind_of: Integer, default: 30
 
 attribute :limit_request_line, kind_of: Integer, default: 4094
 attribute :limit_request_fields, kind_of: Integer, default: 100

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -37,7 +37,7 @@ attribute :worker_max_requests, kind_of: Integer, default: 0
 attribute :worker_max_requests_jitter, kind_of: Integer, default: 0
 attribute :worker_connections, kind_of: Integer, default: 1000
 attribute :worker_threads, kind_of: Integer, default: 1
-attrubyte :worker_graceful_timeout, kind_of: Integer, default: 30
+attrubute :worker_graceful_timeout, kind_of: Integer, default: 30
 
 attribute :limit_request_line, kind_of: Integer, default: 4094
 attribute :limit_request_fields, kind_of: Integer, default: 100

--- a/templates/default/gunicorn.py.erb
+++ b/templates/default/gunicorn.py.erb
@@ -4,19 +4,18 @@
 ##
 
 # What ports/sockets to listen on, and what options for them.
+<%- if @listen.is_a?(Array) %>
+bind = [
+<%- @listen.each do | listen_item | %>
+    "<%= listen_item %>",
+<%- end %>
+]
+<%- else %>
 bind = "<%= @listen %>"
+<%- end %>
 
 # The maximum number of pending connections
 backlog = <%= @backlog %>
-
-# What the timeout for killing busy workers is, in seconds
-timeout = <%= @worker_timeout %>
-
-# How long to wait for requests on a Keep-Alive connection, in seconds
-keepalive = <%= @worker_keepalive %>
-
-# The maxium number of requests a worker will process before restarting
-max_requests = <%= @worker_max_requests %>
 
 # Whether the app should be pre-loaded
 preload_app = <%= @preload_app.to_s.capitalize %>
@@ -27,6 +26,51 @@ workers = <%= @worker_processes %>
 # Type of worker to use
 worker_class = "<%= @worker_class %>"
 
+# What the timeout for killing busy workers is, in seconds
+timeout = <%= @worker_timeout %>
+
+# How long to wait for requests on a Keep-Alive connection, in seconds
+keepalive = <%= @worker_keepalive %>
+
+# The maxium number of requests a worker will process before restarting
+max_requests = <%= @worker_max_requests %>
+
+<%- if @worker_threads %>
+# Number of threads per worker
+threads = <%= @worker_threads %>
+
+<%- end %>
+<%- if @worker_max_requests_jitter %>
+# The maximum jitter to add to the max_requests setting.
+max_requests_jitter = <%= @worker_max_requests_jitter %>
+
+<%- end %>
+
+<%- if @worker_connections %>
+# The maximum number of simultaneous clients.
+worker_connections = <%= @worker_connections %>
+
+<%- end %>
+<%- if @worker_graceful_timeout %>
+# Timeout for graceful workers restart.
+graceful_timeout = <%= @worker_graceful_timeout %>
+
+<%- end %>
+<%- if @limit_request_line %>
+# The maximum size of HTTP request line in bytes.
+limit_request_line = <%= @limit_request_line %>
+
+<%- end %>
+<%- if @limit_request_fields %>
+# Limit the number of HTTP headers fields in a request.
+limit_request_fields = <%= @limit_request_fields %>
+
+<%- end %>
+<%- if @limit_request_field_size %>
+# Limit the allowed size of an HTTP request header field.
+limit_request_field_size = <%= @limit_request_field_size %>
+
+<%- end %>
 <%- if @server_hooks[:on_starting] %>
 # What to do before the master process is initialized
 def on_starting(server):
@@ -133,5 +177,14 @@ forwarded_allow_ips = "<%= @forwarded_allow_ips %>"
 <%- if @proc_name %>
 # A base to use with setproctitle for process naming.
 proc_name = "<%= @proc_name %>"
+
+<%- end %>
+<%- if @raw_env %>
+# OS-level environment variables
+raw_env = [
+<%- @raw_env.each do | raw_var | %>
+  '<%= raw_var %>',
+<%- end %>
+]
 
 <%- end %>


### PR DESCRIPTION
…  Also fixed a small bug in the config attribute defaults that were causing Chef warnings.

### Description

I added support for the following variables:

- worker_connections
- worker_threads
- worker_graceful_timeout
- worker_max_requests_jitter
-limit_request_line
-limit_request_fields
-limit_request_field_size
-raw_env

I also fixed a Chef warning about using {} as a default in resources/config.rb.

### Issues Resolved

None.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
